### PR TITLE
Fix AOT compilation with IL2CPP and .NET 3.5

### DIFF
--- a/csharp/TFG.Protobuff35.nuspec
+++ b/csharp/TFG.Protobuff35.nuspec
@@ -5,13 +5,13 @@
     <title>Google Protocol Buffer</title>
     <summary>Protocol buffers - Google's data interchange format.</summary>
     <description>See project site for more info.</description>
-    <version>3.6.1</version>
+    <version>3.6.2</version>
     <authors>Google Inc.</authors>
     <owners>protobuf-packages</owners>
     <licenseUrl>https://github.com/protocolbuffers/protobuf/blob/master/LICENSE</licenseUrl>
     <projectUrl>https://github.com/protocolbuffers/protobuf</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <releaseNotes>Protocol Buffers compiled for .NET 3.5</releaseNotes>
+    <releaseNotes>Fix AOT compilation when using IL2CPP and .NET 3.5</releaseNotes>
     <copyright>Copyright 2015, Google Inc.</copyright>
     <tags>Protocol Buffers Binary Serialization Format Google proto proto3</tags>
   </metadata>

--- a/csharp/src/Google.Protobuf/Reflection/ReflectionUtil.cs
+++ b/csharp/src/Google.Protobuf/Reflection/ReflectionUtil.cs
@@ -65,6 +65,15 @@ namespace Google.Protobuf.Reflection
             ForceInitialize<bool?>();
             ForceInitialize<SampleEnum>();
             SampleEnumMethod();
+
+            // Force initialization of internal enums for proper AOT
+            // compilation when using IL2CPP and .NET 3.5
+            ForceInitialize<FieldDescriptorProto.Types.Type>();
+            ForceInitialize<FieldDescriptorProto.Types.Label>();
+            ForceInitialize<FieldOptions.Types.CType>();
+            ForceInitialize<FieldOptions.Types.JSType>();
+            ForceInitialize<FileOptions.Types.OptimizeMode>();
+            ForceInitialize<MethodOptions.Types.IdempotencyLevel>();
         }
 
         internal static void ForceInitialize<T>() => new ReflectionHelper<IMessage, T>();


### PR DESCRIPTION
These changes fix AOT compilation when using the protobuf library with IL2CPP scripting backend and .NET 3.5 scripting runtime. Internal protobuf enums need to be used at least once so that the AOT compiler can function properly.

Also, bump C# library version to 3.6.2.